### PR TITLE
Source package builds

### DIFF
--- a/pylib/cmd_get.py
+++ b/pylib/cmd_get.py
@@ -21,6 +21,8 @@ Options:
 
   -t --tree		output dir is in a package tree format (like a repository)
 
+  -o --source       build source packages in addition to binary packages
+
 """
 import sys
 import help
@@ -59,8 +61,8 @@ def read_packages(fh):
     
 def main():
     try:
-        opts, args = getopt.gnu_getopt(sys.argv[1:], 'i:sqt',
-                                       ['input=', 'strict', 'quiet', 'tree'])
+        opts, args = getopt.gnu_getopt(sys.argv[1:], 'i:sqto',
+                                       ['input=', 'strict', 'quiet', 'tree', 'source'])
     except getopt.GetoptError, e:
         usage(e)
 
@@ -74,6 +76,7 @@ def main():
     opt_strict = False
     opt_quiet = False
     opt_tree = False
+    opt_source = False
     
     for opt, val in opts:
         if opt in ('-i', '--input'):
@@ -87,6 +90,8 @@ def main():
             opt_quiet = True
         elif opt in ('-t', '--tree'):
             opt_tree = True
+        elif opt in ('-o', '--source'):
+            opt_source = True
 
     pool = Pool()
     
@@ -98,7 +103,7 @@ def main():
         packages = pool.list()
 
     try:
-        packages = pool.get(outputdir, packages, tree_fmt=opt_tree, strict=opt_strict)
+        packages = pool.get(outputdir, packages, tree_fmt=opt_tree, strict=opt_strict, source=opt_source)
     except pool.Error, e:
         fatal(e)
 

--- a/pylib/pool.py
+++ b/pylib/pool.py
@@ -1072,7 +1072,7 @@ class Pool(object):
 
         try:
             for package in resolved:
-                path_from = self.kernel.getpath_deb(package, source)
+                path_from = self.kernel.getpath_deb(package, source=source)
                 fname = basename(path_from)
 
                 if tree_fmt:

--- a/pylib/pool.py
+++ b/pylib/pool.py
@@ -588,7 +588,7 @@ class Stocks:
         return self.subpools.values()
 
 class PoolPaths(Paths):
-    files = [ "pkgcache", "stocks", "tmp", "build/root", "build/logs" ]
+    files = [ "pkgcache", "stocks", "tmp", "build/root", "build/logs", "build/buildinfo" ]
 
     def __new__(cls, path, create=False):
         return str.__new__(cls, path)
@@ -795,6 +795,8 @@ class PoolKernel(object):
                 self.pkgcache.add(fpath)
             elif fname.endswith(".build"):
                 shutil.copyfile(fpath, join(self.paths.build.logs, fname))
+            elif fname.endswith(".buildinfo"):
+                shutil.copyfile(fpath, join(self.paths.build.buildinfo, fname))
 
         shutil.rmtree(build_outputdir)
 
@@ -968,6 +970,10 @@ class Pool(object):
         mkdir(paths.build.logs)
         Git.anchor(paths.build.logs)
         Git.set_gitignore(paths.build.logs, ["*.build"])
+
+        mkdir(paths.build.buildinfo)
+        Git.anchor(paths.build.buildinfo)
+        Git.set_gitignore(paths.build.buildinfo, ['*.buildinfo'])
 
         Git.set_gitignore(paths.path, ["tmp"])
 

--- a/pylib/pool.py
+++ b/pylib/pool.py
@@ -588,7 +588,7 @@ class Stocks:
         return self.subpools.values()
 
 class PoolPaths(Paths):
-    files = [ "pkgcache", "stocks", "tmp", "build/root", "build/logs", "build/buildinfo" ]
+    files = [ "pkgcache", "stocks", "tmp", "build/root", "build/logs", "build/buildinfo", "srcpkgcache" ]
 
     def __new__(cls, path, create=False):
         return str.__new__(cls, path)
@@ -766,7 +766,7 @@ class PoolKernel(object):
 
         return resolved
 
-    def _build_package_source(self, source_path, name, version):
+    def _build_package_source(self, source_path, name, version, source=False):
         build_outputdir = tempfile.mkdtemp(dir=self.paths.tmp, prefix="%s-%s." % (name, version))
 
         package = self.fmt_package_id(name, version)
@@ -779,7 +779,11 @@ class PoolKernel(object):
 
         # seek to version, build the package, seek back
         verseek.seek(source_path, version)
-        error = os.system("cd %s && deckdebuild %s %s" % mkargs(source_path, self.buildroot, build_outputdir))
+        if source:
+            error = os.system("cd %s && deckdebuild --build-source %s %s" % mkargs(
+                    source_path, self.buildroot, build_outputdir))
+        else:
+            error = os.system("cd %s && deckdebuild %s %s" % mkargs(source_path, self.buildroot, build_outputdir))
         verseek.seek(source_path)
 
         if error:
@@ -791,18 +795,21 @@ class PoolKernel(object):
         # copy *.debs and build output from output dir
         for fname in os.listdir(build_outputdir):
             fpath = join(build_outputdir, fname)
+            fname_part, ext_part = splitext(fname)
             if get_suffix(fname) in ('deb', 'udeb'):
                 self.pkgcache.add(fpath)
             elif fname.endswith(".build"):
                 shutil.copyfile(fpath, join(self.paths.build.logs, fname))
             elif fname.endswith(".buildinfo"):
                 shutil.copyfile(fpath, join(self.paths.build.buildinfo, fname))
+            elif ext_part in ('.gz', '.xz', '.bz2') and splitext(fname_part)[1] == '.tar':
+                shutil.copyfile(fpath, join(self.paths.srcpkgcache, fname))
 
         shutil.rmtree(build_outputdir)
 
 
     @sync
-    def getpath_deb(self, package, build=True):
+    def getpath_deb(self, package, build=True, source=False):
         """Get path to package in pool if it exists or None if it doesn't.
 
         By default if package exists only in source, build and cache it first.
@@ -828,7 +835,7 @@ class PoolKernel(object):
         if not source_path:
             return None
 
-        self._build_package_source(source_path, name, version)
+        self._build_package_source(source_path, name, version, source)
 
         path = self.pkgcache.getpath(name, version)
         if not path:
@@ -965,6 +972,10 @@ class Pool(object):
         Git.anchor(paths.pkgcache)
         Git.set_gitignore(paths.pkgcache, ["*.deb", "*.udeb"])
 
+        mkdir(paths.srcpkgcache)
+        Git.anchor(paths.srcpkgcache)
+        Git.set_gitignore(paths.srcpkgcache, ['*.tar.xz', '*.tar.gz', '*.tar.bz2'])
+
         mkdir(paths.build)
 
         mkdir(paths.build.logs)
@@ -1032,7 +1043,7 @@ class Pool(object):
         packages.sort(cmp=_cmp, reverse=True)
         return packages
 
-    def get(self, output_dir, packages, tree_fmt=False, strict=False):
+    def get(self, output_dir, packages, tree_fmt=False, strict=False, source=False):
         """get packages to output_dir -> resolved Pool.PackageList of packages we got
 
         If strict missing packages raise an exception,
@@ -1061,7 +1072,7 @@ class Pool(object):
 
         try:
             for package in resolved:
-                path_from = self.kernel.getpath_deb(package)
+                path_from = self.kernel.getpath_deb(package, source)
                 fname = basename(path_from)
 
                 if tree_fmt:

--- a/pylib/pool.py
+++ b/pylib/pool.py
@@ -824,7 +824,7 @@ class PoolKernel(object):
             return path
 
         for subpool in self.subpools:
-            path = subpool.getpath_deb(package, build)
+            path = subpool.getpath_deb(package, build, source)
             if path:
                 return path
 


### PR DESCRIPTION
Adds ability to copy source packages into `${POOL_PATH}/.pool/srcpkgcache` provided deckdebuild builds source packages.
Adds ability to pass argument to deckdebuild to build source packages

Related to https://github.com/turnkeylinux/tracker/issues/620

After this and the accompanying deckdebuild PR is merged use the `--source` switch in a `pool-get` command to build both the binary and source packages.