### PR TITLE
don't fail on pool re-install

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -10,7 +10,7 @@ mkdir -p $POOL_PATH
 mkdir -p $BUILDROOT
 
 cd $POOL_PATH
-pool-init $BUILDROOT
+pool-init $BUILDROOT || true
 
 #DEBHELPER#
 


### PR DESCRIPTION
Fixes bug that occurs when re-installing pool after uninstalling (pool dir already initialized)