### PR TITLE
Resolve broken 'info-build'/'info-get' command

### DIFF
--- a/pool_bin
+++ b/pool_bin
@@ -265,6 +265,17 @@ def getpath_build_log(package: str) -> str | None:
     return path
 
 
+def pool_info_build(pool: PoolKernel, package: str) -> None:
+    # TODO - this needs to be completed
+    # - all the functionality required should be in the functions above
+    logger.debug(f"pool_info({pool=}, {package=})")
+    warn(
+        "pool-info-build command is incomplete; please see $POOL_PATH/.pool/"
+        f"build/buildinfo/{package}_<version>_<arch>.buildinfo for buildlog"
+        " and/or pool-info and/or pool-list."
+    )
+
+
 # # pool-info functions
 def print_registered(pool: PoolKernel) -> None:
     logger.debug(f"print_registered({pool=})")
@@ -580,10 +591,10 @@ def main() -> None:
 
     # pool-info-build
     parser_info_build = subparsers.add_parser(
-        "info-get", help="Prints source build log for package"
+        "info-build", help="Prints source build log for package"
     )
     parser_info_build.add_argument("package", help="Package name")
-    parser_info_build.set_defaults(func=pool_get)
+    parser_info_build.set_defaults(func=pool_info_build)
 
     # pool-info
     parser_info = subparsers.add_parser(


### PR DESCRIPTION
I'm not sure what happened but `pool-info-build` is completely broken/incomplete?!:

- parser var name (`info_build`) mismatch with arg/var name (`info-get`)
- calls `pool_get()`
- there is no matching `pool_info_build()`/`pool_info_get()` function

TBH I'm not even 100% sure of the intended functionality? Initially I thought that it was only intended to gather info from a previous build, but the fact that argument name is `info-get` and it calls the `pool_get()` function makes me wonder if it was intended to be `pool-get` but with additional/more verbose output?

Regardless, there are a number of functions under the comment "# pool-info-build functions" that call one another, but the one that appears to be the "top level" one (`getpath_build_log()`) is not called by anything? Plus the current functionality means that it is essentially just an alias for `pool-get` - but given the help, it's not completely clear that is what it does...

I'm not keen to dig any deeper than I already have. I have other much higher priorities so this PR is just a dirty patch up. Or maybe it should just be removed? Maybe just the switch? Or maybe all the code that appears to be intended to be used by `info-build`/`info-get`?

Let me know your thoughts @OnGle and I'll either merge this, or remove the relevant code.